### PR TITLE
ports/riot: fix include in mpconfigport.h

### DIFF
--- a/ports/riot/mpconfigport.h
+++ b/ports/riot/mpconfigport.h
@@ -23,7 +23,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-#include <alloca.h>
+#include <stdlib.h>
 
 #include "irq.h"
 


### PR DESCRIPTION
I found an issue when compiling RIOT-OS with `examples/micropython` on FreeBSD bc of a missing header file. Changing this to use `stdlib.h` instead should work on any other OS such as Linux too, bc on Linux `alloca.h` is included in `stdlib.h`.