### PR TITLE
ports/riot: change for structured GPIO type

### DIFF
--- a/ports/riot/machine_pin.c
+++ b/ports/riot/machine_pin.c
@@ -52,7 +52,11 @@ const mp_obj_base_t machine_pin_obj_template = {&machine_pin_type};
 
 STATIC void machine_pin_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     machine_pin_obj_t *self = self_in;
+#ifndef MODULE_PERIPH_GPIO_EXP
     mp_printf(print, "<Pin %u>", (unsigned)self->pin);
+#else
+    mp_printf(print, "<Pin (%d,%d)>", gpio_port_num(self->pin), self->pin.pin);
+#endif
 }
 
 // pin.init(mode, *, value)


### PR DESCRIPTION
During the migration process of the proposed GPIO API in https://github.com/RIOT-OS/RIOT/pull/14602 we will need two different `printf` calls in `machine_pin_print`. One using the scalar `gpio_t` for platforms that are using the legacy GPIO API and one for the structured `gpio_t` for platforms that already use the new extendable GPIO API.

Both versions have been tested.