### PR TITLE
riot: Use RIOT_CPU instead of RIOT_MCU

### DIFF
--- a/ports/riot/mpconfigport.h
+++ b/ports/riot/mpconfigport.h
@@ -93,7 +93,7 @@
 #define MICROPY_PY_SYS_PLATFORM         "RIOT"
 
 #define MICROPY_HW_BOARD_NAME           "riot-" RIOT_BOARD
-#define MICROPY_HW_MCU_NAME             RIOT_MCU
+#define MICROPY_HW_MCU_NAME             RIOT_CPU
 
 #define MICROPY_MODULE_FROZEN_STR       (1)
 


### PR DESCRIPTION
See https://github.com/RIOT-OS/RIOT/pull/20397 -- after that, RIOT_MCU will not be available any more.

Fixing this here avoids a workaround on the RIOT side.