### PR TITLE
cast old_n_bytes to avoid error at compilation

### DIFF
--- a/py/pystack.h
+++ b/py/pystack.h
@@ -86,6 +86,7 @@ static inline void *mp_nonlocal_alloc(size_t n_bytes) {
 }
 
 static inline void *mp_nonlocal_realloc(void *ptr, size_t old_n_bytes, size_t new_n_bytes) {
+    (void)old_n_bytes;
     return m_renew(uint8_t, ptr, old_n_bytes, new_n_bytes);
 }
 


### PR DESCRIPTION
PR to add @plmorange's [fix for compiler warnings](https://github.com/RIOT-OS/RIOT/pull/21421) in RIOT when using micropython.